### PR TITLE
 修复httplog path路径存在/导致请求失败问题

### DIFF
--- a/vtest.py
+++ b/vtest.py
@@ -473,8 +473,8 @@ def dns_list():
     return jsonify({'total': int(total), 'rows': result})
 
 
-@app.route('/httplog/<str>', methods=['GET', 'POST', 'PUT'])
-def http_log(str):
+@app.route('/httplog/<path:path>', methods=['GET', 'POST', 'PUT'])
+def http_log(path):
     post_data = request.data
     if post_data == '':
         for k,v in request.form.items():


### PR DESCRIPTION
将str改为path即可，不然会爆404从而无法记录