### PR TITLE
修正参数获取错误

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ ADD vtest.py /app/vtest.py
 RUN pip install -r /tmp/requirements.txt
 RUN export PASSWORD=$(python2 -c "import random,string;print(''.join([random.choice(string.ascii_letters) for _ in range(32)]).encode());")
 
-CMD ["sh", "-c", "echo $DOMAIN $LOCALIP $PASSWORD && /usr/local/bin/python2 /app/vtest.py -d $DOMAIN -h $LOCALIP -p $PASSWORD"]
+CMD ["sh", "-c", "echo $DOMAIN $LOCALIP $PASSWORD && /usr/local/bin/python2 /app/vtest.py -d \"$DOMAIN\" -h \"$LOCALIP\" -p \"$PASSWORD\""]

--- a/vtest.py
+++ b/vtest.py
@@ -713,11 +713,11 @@ Usage: python vtest.py -d yourdomain.com [-h 123.123.123.123] [-p password]
             API_TOKEN = md5("ded08972cead38d6ed8f485e5b65b4b6" + PASSWORD)
 
     if LOCAL_IP == '':
-        csock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        csock.connect(('8.8.8.8', 80))
-        (addr, _) = csock.getsockname()
-        csock.close()
-        LOCAL_IP = addr
+        sock = socket.create_connection(('ns1.dnspod.net', 6666), 20)
+        ip = sock.recv(16)
+        sock.close()
+        LOCAL_IP = ip
+        
     DB = sqlite()
     thread.start_new_thread(dns, ())
     app.run('0.0.0.0', 80, threaded=True)


### PR DESCRIPTION
当时用 `DOMAIN=k.aa.cc PASSWORD=xxxx docker-compose up --build` 命令时，命令行获取到的值为
`[('-d', 'k.aa.cc'), ('-h', '-p')]`
在参数上加上双引号，可以获取正确的值
`[('-d', 'k.aa.cc'), ('-h', ''), ('-p', 'xxxx')]`
